### PR TITLE
Revert Use StandardCharsets.UTF_8 for legacy devices compatibility without updating AGP

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
 
-permissions:
-  # The generated docs are written to the `gh-pages` branch.
-  contents: write
-
 jobs:
   build-and-deploy-docs:
     runs-on: ubuntu-latest

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampCommentsExtractor.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.extractor.services.bandcamp.extractors;
 
 import static org.schabi.newpipe.extractor.services.bandcamp.extractors.BandcampExtractorHelper.BASE_API_URL;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
@@ -21,7 +22,6 @@ import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
@@ -107,7 +107,7 @@ public class BandcampCommentsExtractor extends CommentsExtractor {
                             .value("token", token)
                             .value("count", 7)
                             .array("exclude_fan_ids").end()
-                            .end().done().getBytes(StandardCharsets.UTF_8)).responseBody());
+                            .end().done().getBytes(UTF_8)).responseBody());
         } catch (final IOException | ReCaptchaException e) {
             throw new ParsingException("Could not fetch reviews", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampExtractorHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampExtractorHelper.java
@@ -16,12 +16,13 @@ import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Locale;
+
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 public final class BandcampExtractorHelper {
 
@@ -69,7 +70,7 @@ public final class BandcampExtractorHelper {
                             .value("band_id", id)
                             .end()
                             .done()
-                            .getBytes(StandardCharsets.UTF_8)).responseBody());
+                            .getBytes(UTF_8)).responseBody());
         } catch (final IOException | ReCaptchaException | JsonParserException e) {
             throw new ParsingException("Could not download band details", e);
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampFeaturedExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bandcamp/extractors/BandcampFeaturedExtractor.java
@@ -18,10 +18,10 @@ import org.schabi.newpipe.extractor.playlist.PlaylistInfoItemsCollector;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static org.schabi.newpipe.extractor.services.bandcamp.extractors.BandcampExtractorHelper.BASE_API_URL;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 public class BandcampFeaturedExtractor extends KioskExtractor<PlaylistInfoItem> {
 
@@ -45,7 +45,7 @@ public class BandcampFeaturedExtractor extends KioskExtractor<PlaylistInfoItem> 
             json = JsonParser.object().from(getDownloader().postWithContentTypeJson(
                             FEATURED_API_URL,
                             Collections.emptyMap(),
-                            "{\"platform\":\"\",\"version\":0}".getBytes(StandardCharsets.UTF_8))
+                            "{\"platform\":\"\",\"version\":0}".getBytes(UTF_8))
                     .responseBody());
         } catch (final JsonParserException e) {
             throw new ParsingException("Could not parse Bandcamp featured API response", e);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsExtractor.java
@@ -18,12 +18,12 @@ import org.schabi.newpipe.extractor.services.peertube.PeertubeParsingHelper;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import static org.schabi.newpipe.extractor.services.peertube.PeertubeParsingHelper.COUNT_KEY;
 import static org.schabi.newpipe.extractor.services.peertube.PeertubeParsingHelper.ITEMS_PER_PAGE;
 import static org.schabi.newpipe.extractor.services.peertube.PeertubeParsingHelper.START_KEY;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import javax.annotation.Nonnull;
 
@@ -130,7 +130,7 @@ public class PeertubeCommentsExtractor extends CommentsExtractor {
             }
         } else {
             try {
-                json = JsonParser.object().from(new String(page.getBody(), StandardCharsets.UTF_8));
+                json = JsonParser.object().from(new String(page.getBody(), UTF_8));
                 isReply = true;
                 total = json.getArray(CHILDREN).size();
                 collectRepliesFrom(collector, json);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
@@ -17,6 +17,7 @@ import org.schabi.newpipe.extractor.utils.JsonUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.UnsupportedEncodingException;
 import java.util.Objects;
 
 import static org.schabi.newpipe.extractor.services.peertube.extractors.PeertubeCommentsExtractor.CHILDREN;
@@ -136,8 +137,12 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
             // is also structured like a JsonObject.
             final JsonObject pageContent = new JsonObject();
             pageContent.put(CHILDREN, children);
-            return new Page(repliesUrl, threadId,
-                     JsonWriter.string(pageContent).getBytes(UTF_8));
+            try {
+                return new Page(repliesUrl, threadId,
+                         JsonWriter.string(pageContent).getBytes(UTF_8));
+            } catch (final UnsupportedEncodingException e) {
+                throw new ParsingException("no utf8", e);
+            }
         }
         return new Page(repliesUrl, threadId);
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
@@ -136,7 +136,7 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
             // is also structured like a JsonObject.
             final JsonObject pageContent = new JsonObject();
             pageContent.put(CHILDREN, children);
-                return new Page(repliesUrl, threadId,
+            return new Page(repliesUrl, threadId,
                      JsonWriter.string(pageContent).getBytes(UTF_8));
         }
         return new Page(repliesUrl, threadId);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/extractors/PeertubeCommentsInfoItemExtractor.java
@@ -17,10 +17,10 @@ import org.schabi.newpipe.extractor.utils.JsonUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import static org.schabi.newpipe.extractor.services.peertube.extractors.PeertubeCommentsExtractor.CHILDREN;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtractor {
     @Nonnull
@@ -136,8 +136,8 @@ public class PeertubeCommentsInfoItemExtractor implements CommentsInfoItemExtrac
             // is also structured like a JsonObject.
             final JsonObject pageContent = new JsonObject();
             pageContent.put(CHILDREN, children);
-            return new Page(repliesUrl, threadId,
-                     JsonWriter.string(pageContent).getBytes(StandardCharsets.UTF_8));
+                return new Page(repliesUrl, threadId,
+                     JsonWriter.string(pageContent).getBytes(UTF_8));
         }
         return new Page(repliesUrl, threadId);
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -25,6 +25,7 @@ import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
 import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;
 import static org.schabi.newpipe.extractor.utils.Utils.getStringResultFromRegexArray;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonBuilder;
@@ -54,7 +55,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -554,7 +554,7 @@ public final class YoutubeParsingHelper {
                 .end()
                 .value("fetchLiveState", true)
                 .end()
-            .end().done().getBytes(StandardCharsets.UTF_8);
+            .end().done().getBytes(UTF_8);
         // @formatter:on
 
         final var headers = getClientHeaders("1", HARDCODED_CLIENT_VERSION);
@@ -795,7 +795,7 @@ public final class YoutubeParsingHelper {
                     .end()
                 .end()
                 .value("input", "")
-            .end().done().getBytes(StandardCharsets.UTF_8);
+            .end().done().getBytes(UTF_8);
         // @formatter:on
 
         final var headers = new HashMap<>(getOriginReferrerHeaders(YOUTUBE_MUSIC_URL));
@@ -1378,7 +1378,7 @@ public final class YoutubeParsingHelper {
                 .value(CONTENT_CHECK_OK, true)
                 .value(RACY_CHECK_OK, true)
                 .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
         // @formatter:on
     }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeDashManifestCreatorsUtils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/dashmanifestcreators/YoutubeDashManifestCreatorsUtils.java
@@ -8,6 +8,7 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.isTvHtml5SimplyEmbeddedPlayerStreamingUrl;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.isWebStreamingUrl;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.NewPipe;
@@ -25,7 +26,6 @@ import org.w3c.dom.Element;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -623,7 +623,7 @@ public final class YoutubeDashManifestCreatorsUtils {
                 final var headers = Map.of("User-Agent",
                         List.of(isAndroidStreamingUrl ? getAndroidUserAgent(null)
                                 : getIosUserAgent(null)));
-                final byte[] emptyBody = "".getBytes(StandardCharsets.UTF_8);
+                final byte[] emptyBody = "".getBytes(UTF_8);
                 return downloader.post(baseStreamingUrl, headers, emptyBody);
             } catch (final IOException | ExtractionException e) {
                 throw new CreationException("Could not get the "

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -7,6 +7,7 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareDesktopJsonBuilder;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
@@ -29,7 +30,6 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -95,7 +95,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                             getExtractorLocalization(), getExtractorContentCountry())
                             .value("url", "https://www.youtube.com/" + channelPath)
                             .done())
-                    .getBytes(StandardCharsets.UTF_8);
+                    .getBytes(UTF_8);
 
             final JsonObject jsonResponse = getJsonPostResponse("navigation/resolve_url",
                     body, getExtractorLocalization());
@@ -133,7 +133,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                             .value("browseId", id)
                             .value("params", "EgZ2aWRlb3M%3D") // Equal to videos
                             .done())
-                    .getBytes(StandardCharsets.UTF_8);
+                    .getBytes(UTF_8);
 
             final JsonObject jsonResponse = getJsonPostResponse("browse", body,
                     getExtractorLocalization());
@@ -429,7 +429,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                         getExtractorContentCountry())
                         .value("continuation", continuation)
                         .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
 
         return new Page(YOUTUBEI_V1_URL + "browse?key=" + getKey()
                 + DISABLE_PRETTY_PRINT_PARAMETER, null, channelIds, null, body);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -19,7 +19,6 @@ import org.schabi.newpipe.extractor.utils.Utils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
@@ -27,6 +26,7 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareDesktopJsonBuilder;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 public class YoutubeCommentsExtractor extends CommentsExtractor {
 
@@ -191,7 +191,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
                 prepareDesktopJsonBuilder(localization, getExtractorContentCountry())
                     .value("continuation", page.getId())
                     .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
         // @formatter:on
 
         final JsonObject jsonObject = getJsonPostResponse("next", body, localization);
@@ -272,7 +272,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
                 prepareDesktopJsonBuilder(localization, getExtractorContentCountry())
                     .value("videoId", getId())
                     .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
         // @formatter:on
 
         final String initialToken =
@@ -287,7 +287,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
                         prepareDesktopJsonBuilder(localization, getExtractorContentCountry())
                                 .value("continuation", initialToken)
                                 .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
         // @formatter:on
 
         ajaxJson = getJsonPostResponse("next", ajaxBody, localization);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMixPlaylistExtractor.java
@@ -11,6 +11,7 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import static org.schabi.newpipe.extractor.utils.Utils.getQueryValue;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 import static org.schabi.newpipe.extractor.utils.Utils.stringToURL;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonBuilder;
@@ -38,7 +39,6 @@ import org.schabi.newpipe.extractor.utils.JsonUtils;
 
 import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +87,7 @@ public class YoutubeMixPlaylistExtractor extends PlaylistExtractor {
             jsonBody.value("playlistIndex", Integer.parseInt(playlistIndexString));
         }
 
-        final byte[] body = JsonWriter.string(jsonBody.done()).getBytes(StandardCharsets.UTF_8);
+        final byte[] body = JsonWriter.string(jsonBody.done()).getBytes(UTF_8);
 
         // Cookie is required due to consent
         final var headers = getYouTubeHeaders();
@@ -212,7 +212,7 @@ public class YoutubeMixPlaylistExtractor extends PlaylistExtractor {
                 .value("playlistIndex", index)
                 .value("params", params)
                 .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
 
         return new Page(YOUTUBEI_V1_URL + "next?key=" + getKey(), null, null, cookies, body);
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeMusicSearchExtractor.java
@@ -12,6 +12,7 @@ import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeS
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.MUSIC_SONGS;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.MUSIC_VIDEOS;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
@@ -38,7 +39,6 @@ import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -112,7 +112,7 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
                 .end()
                 .value("query", getSearchString())
                 .value("params", params)
-            .end().done().getBytes(StandardCharsets.UTF_8);
+            .end().done().getBytes(UTF_8);
         // @formatter:on
 
         final String responseBody = getValidJsonResponseBody(
@@ -240,7 +240,7 @@ public class YoutubeMusicSearchExtractor extends SearchExtractor {
                         .value("enableSafetyMode", false)
                     .end()
                 .end()
-            .end().done().getBytes(StandardCharsets.UTF_8);
+            .end().done().getBytes(UTF_8);
         // @formatter:on
 
         final String responseBody = getValidJsonResponseBody(

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -10,6 +10,7 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getUrlFromNavigationEndpoint;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareDesktopJsonBuilder;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
@@ -32,7 +33,6 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -66,7 +66,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
                         .value("browseId", "VL" + getId())
                         .value("params", "wgYCCAA%3D") // Show unavailable videos
                         .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
 
         browseResponse = getJsonPostResponse("browse", body, localization);
         YoutubeParsingHelper.defaultAlertsCheck(browseResponse);
@@ -387,7 +387,7 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
                             getExtractorLocalization(), getExtractorContentCountry())
                             .value("continuation", continuation)
                             .done())
-                    .getBytes(StandardCharsets.UTF_8);
+                    .getBytes(UTF_8);
 
             return new Page(YOUTUBEI_V1_URL + "browse?key=" + getKey()
                     + DISABLE_PRETTY_PRINT_PARAMETER, body);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSearchExtractor.java
@@ -8,6 +8,7 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareDesktopJsonBuilder;
 import static org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQueryHandlerFactory.getSearchParameter;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonBuilder;
@@ -30,7 +31,6 @@ import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -87,7 +87,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
             jsonBody.value("params", params);
         }
 
-        final byte[] body = JsonWriter.string(jsonBody.done()).getBytes(StandardCharsets.UTF_8);
+        final byte[] body = JsonWriter.string(jsonBody.done()).getBytes(UTF_8);
 
         initialData = getJsonPostResponse("search", body, localization);
     }
@@ -190,7 +190,7 @@ public class YoutubeSearchExtractor extends SearchExtractor {
                 getExtractorContentCountry())
                 .value("continuation", page.getId())
                 .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
         // @formatter:on
 
         final JsonObject ajaxJson = getJsonPostResponse("search", json, localization);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -39,6 +39,7 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareDesktopJsonBuilder;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareIosMobileJsonBuilder;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
@@ -88,7 +89,6 @@ import org.schabi.newpipe.extractor.utils.Parser;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -900,7 +900,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                         .value(CONTENT_CHECK_OK, true)
                         .value(RACY_CHECK_OK, true)
                         .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
         nextResponse = getJsonPostResponse(NEXT, body, localization);
 
         // streamType can only have LIVE_STREAM, POST_LIVE_STREAM and VIDEO_STREAM values (see
@@ -1007,7 +1007,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                         // using some parameters for Android client requests
                         .value("params", "CgIQBg")
                         .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
 
         final JsonObject androidPlayerResponse = getJsonAndroidPostResponse(PLAYER,
                 mobileBody, localization, "&t=" + generateTParameter()
@@ -1042,7 +1042,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                         .value(CONTENT_CHECK_OK, true)
                         .value(RACY_CHECK_OK, true)
                         .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
 
         final JsonObject iosPlayerResponse = getJsonIosPostResponse(PLAYER,
                 mobileBody, localization, "&t=" + generateTParameter()

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
@@ -24,6 +24,7 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextAtKey;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareDesktopJsonBuilder;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonWriter;
@@ -40,7 +41,6 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemsCollector;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
@@ -65,7 +65,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
                 .value("browseId", "FEtrending")
                 .value("params", VIDEOS_TAB_PARAMS)
                 .done())
-                .getBytes(StandardCharsets.UTF_8);
+                .getBytes(UTF_8);
         // @formatter:on
 
         initialData = getJsonPostResponse("browse", body, getExtractorLocalization());

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/utils/Utils.java
@@ -7,7 +7,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -21,6 +20,7 @@ import javax.annotation.Nullable;
 public final class Utils {
     public static final String HTTP = "http://";
     public static final String HTTPS = "https://";
+    public static final String UTF_8 = "UTF-8";
     private static final Pattern M_PATTERN = Pattern.compile("(https?)?://m\\.");
     private static final Pattern WWW_PATTERN = Pattern.compile("(https?)?://www\\.");
 
@@ -37,7 +37,7 @@ public final class Utils {
      */
     public static String encodeUrlUtf8(final String string) throws UnsupportedEncodingException {
         // TODO: Switch to URLEncoder.encode(String, Charset) in Java 10.
-        return URLEncoder.encode(string, StandardCharsets.UTF_8.name());
+        return URLEncoder.encode(string, UTF_8);
     }
 
     /**
@@ -48,7 +48,7 @@ public final class Utils {
      */
     public static String decodeUrlUtf8(final String url) throws UnsupportedEncodingException {
         // TODO: Switch to URLDecoder.decode(String, Charset) in Java 10.
-        return URLDecoder.decode(url, StandardCharsets.UTF_8.name());
+        return URLDecoder.decode(url, UTF_8);
     }
 
     /**


### PR DESCRIPTION
Allow for old android version without updating AGP. Based on https://github.com/SkyTubeTeam/NewPipeExtractor/commit/a473ed1be85c47962688a17a596fb30a9918b23d

This partially reverts commit 366f5c1632c38a2dc376dd472ba81f554eba51b8

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
