### PR TITLE
[YouTube] Extract trends from A/B tested "Videos" tab and fix extraction of trends name from A/B tested new title design

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeTrendingExtractor.java
@@ -41,11 +41,14 @@ import javax.annotation.Nonnull;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getJsonPostResponse;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextAtKey;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareDesktopJsonBuilder;
+import java.util.stream.Stream;
 import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
 public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
     private JsonObject initialData;
+
+    private static final String VIDEOS_TAB_PARAMS = "4gIOGgxtb3N0X3BvcHVsYXI%3D";
 
     public YoutubeTrendingExtractor(final StreamingService service,
                                     final ListLinkHandler linkHandler,
@@ -60,6 +63,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
         final byte[] body = JsonWriter.string(prepareDesktopJsonBuilder(getExtractorLocalization(),
                 getExtractorContentCountry())
                 .value("browseId", "FEtrending")
+                .value("params", VIDEOS_TAB_PARAMS)
                 .done())
                 .getBytes(UTF_8);
         // @formatter:on
@@ -81,6 +85,8 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
             name = getTextAtKey(header.getObject("feedTabbedHeaderRenderer"), "title");
         } else if (header.has("c4TabbedHeaderRenderer")) {
             name = getTextAtKey(header.getObject("c4TabbedHeaderRenderer"), "title");
+        } else if (header.has("pageHeaderRenderer")) {
+            name = getTextAtKey(header.getObject("pageHeaderRenderer"), "pageTitle");
         }
 
         if (isNullOrEmpty(name)) {
@@ -94,7 +100,10 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
     public InfoItemsPage<StreamInfoItem> getInitialPage() throws ParsingException {
         final StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
         final TimeAgoParser timeAgoParser = getTimeAgoParser();
-        final JsonObject tabContent = getTrendingTabContent();
+        final JsonObject tab = getTrendingTab();
+        final JsonObject tabContent = tab.getObject("content");
+        final boolean isVideoTab = tab.getObject("endpoint").getObject("browseEndpoint")
+                .getString("params", "").equals(VIDEOS_TAB_PARAMS);
 
         if (tabContent.has("richGridRenderer")) {
             tabContent.getObject("richGridRenderer")
@@ -110,7 +119,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
                     .forEachOrdered(videoRenderer -> collector.commit(
                             new YoutubeStreamInfoItemExtractor(videoRenderer, timeAgoParser)));
         } else if (tabContent.has("sectionListRenderer")) {
-            tabContent.getObject("sectionListRenderer")
+            final Stream<JsonObject> shelves = tabContent.getObject("sectionListRenderer")
                     .getArray("contents")
                     .stream()
                     .filter(JsonObject.class::isInstance)
@@ -120,11 +129,19 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
                             .stream())
                     .filter(JsonObject.class::isInstance)
                     .map(JsonObject.class::cast)
-                    .map(content -> content.getObject("shelfRenderer"))
-                    // Filter Trending shorts and Recently trending sections which have a title,
-                    // contrary to normal trends
-                    .filter(shelfRenderer -> !shelfRenderer.has("title"))
-                    .flatMap(shelfRenderer -> shelfRenderer.getObject("content")
+                    .map(content -> content.getObject("shelfRenderer"));
+
+            final Stream<JsonObject> items;
+            if (isVideoTab) {
+                // The first shelf of the Videos tab contains the normal trends
+                items = shelves.findFirst().stream();
+            } else {
+                // Filter Trending shorts and Recently trending sections which have a title,
+                // contrary to normal trends
+                items = shelves.filter(shelfRenderer -> !shelfRenderer.has("title"));
+            }
+
+            items.flatMap(shelfRenderer -> shelfRenderer.getObject("content")
                             .getObject("expandedShelfContentsRenderer")
                             .getArray("items")
                             .stream())
@@ -138,7 +155,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
         return new InfoItemsPage<>(collector, null);
     }
 
-    private JsonObject getTrendingTabContent() throws ParsingException {
+    private JsonObject getTrendingTab() throws ParsingException {
         return initialData.getObject("contents")
                 .getObject("twoColumnBrowseResultsRenderer")
                 .getArray("tabs")
@@ -150,7 +167,7 @@ public class YoutubeTrendingExtractor extends KioskExtractor<StreamInfoItem> {
                 .filter(tabRenderer -> tabRenderer.has("content"))
                 // There should be at most one tab selected
                 .findFirst()
-                .orElseThrow(() -> new ParsingException("Could not get \"Now\" trending tab"))
-                .getObject("content");
+                .orElseThrow(() ->
+                        new ParsingException("Could not get \"Now\" or \"Videos\" trending tab"));
     }
 }

--- a/extractor/src/test/resources/org/schabi/newpipe/extractor/services/youtube/extractor/kiosk/trending/generated_mock_0.json
+++ b/extractor/src/test/resources/org/schabi/newpipe/extractor/services/youtube/extractor/kiosk/trending/generated_mock_0.json
@@ -3,10 +3,10 @@
     "httpMethod": "GET",
     "url": "https://www.youtube.com/sw.js",
     "headers": {
-      "Origin": [
+      "Referer": [
         "https://www.youtube.com"
       ],
-      "Referer": [
+      "Origin": [
         "https://www.youtube.com"
       ],
       "Accept-Language": [
@@ -29,7 +29,7 @@
         "https://www.youtube.com"
       ],
       "alt-svc": [
-        "h3\u003d\":443\"; ma\u003d2592000,h3-29\u003d\":443\"; ma\u003d2592000,h3-Q050\u003d\":443\"; ma\u003d2592000,h3-Q046\u003d\":443\"; ma\u003d2592000,h3-Q043\u003d\":443\"; ma\u003d2592000,quic\u003d\":443\"; ma\u003d2592000; v\u003d\"46,43\""
+        "h3\u003d\":443\"; ma\u003d2592000,h3-29\u003d\":443\"; ma\u003d2592000"
       ],
       "cache-control": [
         "private, max-age\u003d0"
@@ -40,14 +40,17 @@
       "critical-ch": [
         "Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List, Sec-CH-UA-Model, Sec-CH-UA-Platform, Sec-CH-UA-Platform-Version"
       ],
-      "cross-origin-opener-policy-report-only": [
+      "cross-origin-opener-policy": [
         "same-origin; report-to\u003d\"youtube_main\""
       ],
       "date": [
-        "Fri, 12 Aug 2022 17:15:40 GMT"
+        "Sun, 16 Apr 2023 17:42:25 GMT"
       ],
       "expires": [
-        "Fri, 12 Aug 2022 17:15:40 GMT"
+        "Sun, 16 Apr 2023 17:42:25 GMT"
+      ],
+      "origin-trial": [
+        "AvC9UlR6RDk2crliDsFl66RWLnTbHrDbp+DiY6AYz/PNQ4G4tdUTjrHYr2sghbkhGQAVxb7jaPTHpEVBz0uzQwkAAAB4eyJvcmlnaW4iOiJodHRwczovL3lvdXR1YmUuY29tOjQ0MyIsImZlYXR1cmUiOiJXZWJWaWV3WFJlcXVlc3RlZFdpdGhEZXByZWNhdGlvbiIsImV4cGlyeSI6MTcxOTUzMjc5OSwiaXNTdWJkb21haW4iOnRydWV9"
       ],
       "p3p": [
         "CP\u003d\"This is not a P3P policy! See http://support.google.com/accounts/answer/151657?hl\u003den-GB for more info.\""
@@ -62,9 +65,9 @@
         "ESF"
       ],
       "set-cookie": [
-        "YSC\u003dkoiv-HhOPrg; Domain\u003d.youtube.com; Path\u003d/; Secure; HttpOnly; SameSite\u003dnone",
-        "VISITOR_INFO1_LIVE\u003d; Domain\u003d.youtube.com; Expires\u003dSat, 16-Nov-2019 17:15:40 GMT; Path\u003d/; Secure; HttpOnly; SameSite\u003dnone",
-        "CONSENT\u003dPENDING+636; expires\u003dSun, 11-Aug-2024 17:15:40 GMT; path\u003d/; domain\u003d.youtube.com; Secure"
+        "YSC\u003deNq1o5_KNzg; Domain\u003d.youtube.com; Path\u003d/; Secure; HttpOnly; SameSite\u003dnone",
+        "VISITOR_INFO1_LIVE\u003d; Domain\u003d.youtube.com; Expires\u003dMon, 20-Jul-2020 17:42:25 GMT; Path\u003d/; Secure; HttpOnly; SameSite\u003dnone",
+        "CONSENT\u003dPENDING+549; expires\u003dTue, 15-Apr-2025 17:42:25 GMT; path\u003d/; domain\u003d.youtube.com; Secure"
       ],
       "strict-transport-security": [
         "max-age\u003d31536000"

--- a/extractor/src/test/resources/org/schabi/newpipe/extractor/services/youtube/extractor/kiosk/trending/generated_mock_1.json
+++ b/extractor/src/test/resources/org/schabi/newpipe/extractor/services/youtube/extractor/kiosk/trending/generated_mock_1.json
@@ -20,7 +20,7 @@
     "responseMessage": "",
     "responseHeaders": {
       "alt-svc": [
-        "h3\u003d\":443\"; ma\u003d2592000,h3-29\u003d\":443\"; ma\u003d2592000,h3-Q050\u003d\":443\"; ma\u003d2592000,h3-Q046\u003d\":443\"; ma\u003d2592000,h3-Q043\u003d\":443\"; ma\u003d2592000,quic\u003d\":443\"; ma\u003d2592000; v\u003d\"46,43\""
+        "h3\u003d\":443\"; ma\u003d2592000,h3-29\u003d\":443\"; ma\u003d2592000"
       ],
       "cache-control": [
         "no-cache, no-store, max-age\u003d0, must-revalidate"
@@ -28,14 +28,17 @@
       "content-type": [
         "text/html; charset\u003dutf-8"
       ],
-      "cross-origin-opener-policy-report-only": [
+      "cross-origin-opener-policy": [
         "same-origin-allow-popups; report-to\u003d\"youtube_main\""
       ],
       "date": [
-        "Fri, 12 Aug 2022 17:15:40 GMT"
+        "Sun, 16 Apr 2023 17:42:25 GMT"
       ],
       "expires": [
         "Mon, 01 Jan 1990 00:00:00 GMT"
+      ],
+      "origin-trial": [
+        "AvC9UlR6RDk2crliDsFl66RWLnTbHrDbp+DiY6AYz/PNQ4G4tdUTjrHYr2sghbkhGQAVxb7jaPTHpEVBz0uzQwkAAAB4eyJvcmlnaW4iOiJodHRwczovL3lvdXR1YmUuY29tOjQ0MyIsImZlYXR1cmUiOiJXZWJWaWV3WFJlcXVlc3RlZFdpdGhEZXByZWNhdGlvbiIsImV4cGlyeSI6MTcxOTUzMjc5OSwiaXNTdWJkb21haW4iOnRydWV9"
       ],
       "p3p": [
         "CP\u003d\"This is not a P3P policy! See http://support.google.com/accounts/answer/151657?hl\u003den-GB for more info.\""
@@ -53,9 +56,9 @@
         "ESF"
       ],
       "set-cookie": [
-        "YSC\u003dm8gSDNdggLc; Domain\u003d.youtube.com; Path\u003d/; Secure; HttpOnly; SameSite\u003dnone",
-        "VISITOR_INFO1_LIVE\u003d; Domain\u003d.youtube.com; Expires\u003dSat, 16-Nov-2019 17:15:40 GMT; Path\u003d/; Secure; HttpOnly; SameSite\u003dnone",
-        "__Secure-YEC\u003dCgtNY09qSVAzU2xoWSi8ldqXBg%3D%3D; Domain\u003d.youtube.com; Expires\u003dMon, 11-Sep-2023 17:15:39 GMT; Path\u003d/; Secure; HttpOnly; SameSite\u003dlax"
+        "YSC\u003dquqJbwlWjeg; Domain\u003d.youtube.com; Path\u003d/; Secure; HttpOnly; SameSite\u003dnone",
+        "VISITOR_INFO1_LIVE\u003d; Domain\u003d.youtube.com; Expires\u003dMon, 20-Jul-2020 17:42:25 GMT; Path\u003d/; Secure; HttpOnly; SameSite\u003dnone",
+        "__Secure-YEC\u003dCgtoeGlra2FJX3p3NCiB5_ChBg%3D%3D; Domain\u003d.youtube.com; Expires\u003dWed, 15-May-2024 17:42:24 GMT; Path\u003d/; Secure; HttpOnly; SameSite\u003dlax"
       ],
       "strict-transport-security": [
         "max-age\u003d31536000"

--- a/extractor/src/test/resources/org/schabi/newpipe/extractor/services/youtube/extractor/kiosk/trending/generated_mock_2.json
+++ b/extractor/src/test/resources/org/schabi/newpipe/extractor/services/youtube/extractor/kiosk/trending/generated_mock_2.json
@@ -3,17 +3,17 @@
     "httpMethod": "POST",
     "url": "https://www.youtube.com/youtubei/v1/browse?key\u003dAIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8\u0026prettyPrint\u003dfalse",
     "headers": {
-      "Origin": [
+      "Referer": [
         "https://www.youtube.com"
       ],
       "X-YouTube-Client-Name": [
         "1"
       ],
-      "Referer": [
+      "Origin": [
         "https://www.youtube.com"
       ],
       "X-YouTube-Client-Version": [
-        "2.20220809.02.00"
+        "2.20230414.01."
       ],
       "Content-Type": [
         "application/json"
@@ -318,10 +318,10 @@
         "application/json; charset\u003dUTF-8"
       ],
       "date": [
-        "Fri, 12 Aug 2022 17:15:41 GMT"
+        "Sun, 16 Apr 2023 17:35:48 GMT"
       ],
       "expires": [
-        "Fri, 12 Aug 2022 17:15:41 GMT"
+        "Sun, 16 Apr 2023 17:35:48 GMT"
       ],
       "p3p": [
         "CP\u003d\"This is not a P3P policy! See g.co/p3phelp for more info.\""


### PR DESCRIPTION
YouTube is A/B testing a new layout for the trending page, where they moved the list of trending videos into a separate tab.

Theta-Dev has changed the extractor to fetch this new tab. If the new layout is not enabled, YT simple returns the Now page like before.

The parser had to be adjusted, because we cannot filter out all shelves with titles any more (the shelves in the Videos tab have titles).

AudricV: fix: YouTube trending name extraction

- [ ] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
