### PR TITLE
[YT] Fix cannot view any channel content parsing error could not get channel id

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -92,8 +92,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
         // we couldn't get information about the channel associated with this URL, if there is one.
         if (channelId[0].startsWith("UC")) {
             id = channelId[0];
-        }   
-        else {
+        } else {
             final byte[] body = JsonWriter.string(prepareDesktopJsonBuilder(
                             getExtractorLocalization(), getExtractorContentCountry())
                             .value("url", "https://www.youtube.com/" + channelPath)
@@ -124,7 +123,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                 id = browseId;
                 redirectedChannelId = browseId;
             }
-        } 
+        }
         JsonObject ajaxJson = null;
 
         int level = 0;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -90,7 +90,10 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
         // If the url is an URL which is not a /channel URL, we need to use the
         // navigation/resolve_url endpoint of the InnerTube API to get the channel id. Otherwise,
         // we couldn't get information about the channel associated with this URL, if there is one.
-        if (!channelId[0].equals("channel")) {
+        if (channelId[0].startsWith("UC")) {
+            id = channelId[0];
+        }   
+        else {
             final byte[] body = JsonWriter.string(prepareDesktopJsonBuilder(
                             getExtractorLocalization(), getExtractorContentCountry())
                             .value("url", "https://www.youtube.com/" + channelPath)
@@ -121,9 +124,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                 id = browseId;
                 redirectedChannelId = browseId;
             }
-        } else {
-            id = channelId[1];
-        }
+        } 
         JsonObject ajaxJson = null;
 
         int level = 0;
@@ -131,7 +132,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
             final byte[] body = JsonWriter.string(prepareDesktopJsonBuilder(
                             getExtractorLocalization(), getExtractorContentCountry())
                             .value("browseId", id)
-                            .value("params", "EgZ2aWRlb3M%3D") // Equal to videos
+                            .value("params", "EgZ2aWRlb3PyBgQKAjoA") // Equal to videos
                             .done())
                     .getBytes(UTF_8);
 
@@ -208,6 +209,10 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                         .filter(itm -> itm.has("topicChannelDetailsRenderer"))
                         .findFirst()
                         .map(itm -> itm.getObject("topicChannelDetailsRenderer"));
+            } else if (h.has("pageHeaderRenderer")) {
+                channelHeader = Optional.of(h.getObject("pageHeaderRenderer"));
+            } else if (h.has("interactiveTabbedHeaderRenderer")) {
+                channelHeader = Optional.of(h.getObject("interactiveTabbedHeaderRenderer"));
             } else {
                 channelHeader = Optional.empty();
             }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [x] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [] I agree to create a pull request for [NewPipeZing](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.

Channel videos are showing but channel Subscriber Count & channel
avtar is not yet being parsed.

Thanks to @matecky for code for legacy extractor.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #45 

#### APK testing
[NewPipe_zing_channel_fix.zip](https://github.com/user-attachments/files/16184143/NewPipe_zing_channel_fix.zip)
