### PR TITLE
Extract visitor data from sw.js_data API instead of randomly

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -80,6 +80,11 @@ public final class YoutubeParsingHelper {
     }
 
     /**
+     * The base URL for plain Youtube.
+     */
+    public static final String YOUTUBE_BASE = "https://www.youtube.com/";
+
+    /**
      * The base URL of requests of the {@code WEB} clients to the InnerTube internal API.
      */
     public static final String YOUTUBEI_V1_URL = "https://www.youtube.com/youtubei/v1/";
@@ -213,6 +218,11 @@ public final class YoutubeParsingHelper {
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
     /**
+     * Regex for extracing any JSON array.
+     */
+    private static final String JSON_ARRAY = "\\[.*\\]";
+
+    /**
      * The device machine id for the iPhone 15 Pro Max,
      * used to get 60fps with the {@code iOS} client.
      *
@@ -320,6 +330,35 @@ public final class YoutubeParsingHelper {
         pb.varint(5, System.currentTimeMillis() / 1000 - numberGenerator.nextInt(600000));
         pb.bytes(6, pbE.toBytes());
         return pb.toUrlencodedBase64();
+    }
+
+    /**
+     * Requests and parses out the visitor data from the sw.js_data YT endpoint.
+     * This function does not parse it into a programmatic form, just returns the encoded string.
+     * Useful for passing into API requests which require visitorData to work.
+     * The function currently uses very brittle extraction logic.
+     * Likely to fail with future changes.
+     *
+     * @return extracted encoded visitor data string
+     * @throws ParsingException if the format of data is no longer a JSON array
+     * @throws IOException when it cannot fetch the API data
+     * @throws ReCaptchaException when it cannot fetch the API data
+     */
+    public static String extractVisitorData()
+            throws ParsingException, IOException, ReCaptchaException {
+        final String url = YOUTUBE_BASE + "sw.js_data";
+        final var headers = getOriginReferrerHeaders(YOUTUBE_BASE);
+        final String response = getDownloader().get(url, headers).responseBody();
+        final JsonArray jsonArray = JsonUtils.toJsonArray(
+                Parser.matchGroup(JSON_ARRAY, response, 0));
+        // Got this particular extraction logic by finding where the visitor data
+        // lives through comparison. If the structure changes this is likely to fail.
+        return jsonArray
+                .getArray(0)
+                .getArray(2)
+                .getArray(0)
+                .getArray(0)
+                .getString(13);
     }
 
     /**
@@ -1264,6 +1303,16 @@ public final class YoutubeParsingHelper {
     public static JsonBuilder<JsonObject> prepareIosMobileJsonBuilder(
             @Nonnull final Localization localization,
             @Nonnull final ContentCountry contentCountry) {
+
+        // Try to extract the visitor data from the sw.js_data API, but otherwise
+        // fall back to randomly generating the visitor data.
+        String visitorData = null;
+        try {
+            visitorData = extractVisitorData();
+        } catch (ParsingException | IOException | ReCaptchaException e) {
+            visitorData = randomVisitorData(contentCountry);
+        }
+
         // @formatter:off
         return JsonObject.builder()
                 .object("context")
@@ -1276,7 +1325,7 @@ public final class YoutubeParsingHelper {
                         .value("platform", "MOBILE")
                         .value("osName", "iOS")
                         .value("osVersion", IOS_OS_VERSION)
-                        .value("visitorData", randomVisitorData(contentCountry))
+                        .value("visitorData", visitorData)
                         .value("hl", localization.getLocalizationCode())
                         .value("gl", contentCountry.getCountryCode())
                         .value("utcOffsetMinutes", 0)


### PR DESCRIPTION
Visitor data was randomly generated for the iOS client, but this has recently broken. This PR tries to extract this data from https://www.youtube.com/sw.js_data
Author: Max Guichard

- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
- [ ] I have tested the API against [NewPipe](https://github.com/TeamNewPipe/NewPipe).
- [ ] I agree to create a pull request for [NewPipe](https://github.com/TeamNewPipe/NewPipe) as soon as possible to make it compatible with the changed API.
